### PR TITLE
comment-fixes

### DIFF
--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfObjectPropertyShouldExpression.class/README.md
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfObjectPropertyShouldExpression.class/README.md
@@ -1,6 +1,6 @@
 I implement special hook to validate internal object properties by should expressions. I am created for property validation:
 	
-	(1@0) which x should equal: 1
+	(1@0) where x should equal: 1
 
 should here returns me.
 

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfObjectPropertyShouldExpression.class/properties.json
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfObjectPropertyShouldExpression.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "DenisKudryashov 3/2/2016 18:07",
+	"commentStamp" : "chaetal 2/8/2018 11:35",
 	"super" : "SpecOfShouldExpression",
 	"category" : "StateSpecs-DSL-ShouldExpressions",
 	"classinstvars" : [ ],

--- a/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/include..st
+++ b/StateSpecs-DSL-ShouldExpressions.package/SpecOfShouldExpression.class/instance/include..st
@@ -1,3 +1,3 @@
 expressions
-include: anObject 
-	^self verify: (SpecOfCollectionContents requiredItem: anObject)
+include: anObject
+	^ self verify: (SpecOfCollectionContents requiredItem: anObject).

--- a/StateSpecs-Specs-Tests.package/SpecOfClassExtensionsTests.class/instance/testPrintingBlockForSpecTitle.st
+++ b/StateSpecs-Specs-Tests.package/SpecOfClassExtensionsTests.class/instance/testPrintingBlockForSpecTitle.st
@@ -1,7 +1,6 @@
 tests
 testPrintingBlockForSpecTitle
 	| result |
-	
-	result := [:blockArg | blockArg > 0] stringForSpecTitle.
-	
-	self assert: result = '[ :blockArg | blockArg > 0 ]'
+	result := [ :blockArg | blockArg > 0. ] stringForSpecTitle.
+
+	self assert: result equals: [ :blockArg | blockArg > 0. ] printString.

--- a/StateSpecs-Specs.package/SpecOfCollectionContents.class/instance/basicMatches..st
+++ b/StateSpecs-Specs.package/SpecOfCollectionContents.class/instance/basicMatches..st
@@ -1,3 +1,3 @@
 testing
 basicMatches: aCollection 
-	^aCollection includes: requiredItem
+	^aCollection anySatisfy: [ :each | requiredItem asStateSpec matches: each]


### PR DESCRIPTION
Now  a State Spec can be used as should include: argument.
Small refactoring in the testPrintingB.ockForSpecTitle due to various pretty printing settings are possible